### PR TITLE
FIX: Adds support for C99 Bool Type returned by Swift methods.

### DIFF
--- a/cslim.podspec
+++ b/cslim.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "cslim"
-  s.version      = "1.0.3"
+  s.version      = "1.0.2"
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
 
   s.name         = "cslim"
-  s.version      = "1.0.1"
+  s.version      = "1.0.3"
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }
   s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
   s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "v#{s.version}" }
-  s.source_files  = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*', 'fixtures/Main.c'
+  s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*'
   s.private_header_files = "**/*.h"
 end

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "cslim"
-  s.version      = "1.0.2"
+  s.version      = "1.1"
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }

--- a/src/ExecutorObjectiveC/OCSReturnValue.m
+++ b/src/ExecutorObjectiveC/OCSReturnValue.m
@@ -11,7 +11,7 @@
         id result;
         [invocation getReturnValue: &result];
         return [OCSReturnValue forObjectOrPrimitive: result
-                                 andMethodSignature: invocation.methodSignature];
+                          andMethodSignature: invocation.methodSignature];
     }
 }
 
@@ -31,6 +31,8 @@
         return object;
     } else if([NSStringFromClass([object class]) isEqualToString: @"__NSCFConstantString"]) {
         return object;
+    } else if ([NSStringFromClass([object class]) isEqualToString:@"NSTaggedPointerString"]) {
+        return object;
     } else if ([NSStringFromClass([object class]) isEqualToString:@"__NSArrayI"]) {
         return [self forNSArray:object];
     } else if ([NSStringFromClass([object class]) isEqualToString:@"__NSCFBoolean"]) {
@@ -43,7 +45,7 @@
 + (NSString *) forPrimitive:(id)primitive withReturnType:(NSString*)returnType {
     if ([returnType isEqualToString: @"i"]) {
         return [NSString stringWithFormat: @"%i", (int)primitive];
-    } else if ([returnType isEqualToString: @"c"]) {
+    } else if ([returnType isEqualToString: @"c"] || [returnType isEqualToString:@"B"]) {
         return ((BOOL)primitive) ? @"true" : @"false";
     } else {
         return @"OK";

--- a/src/ExecutorObjectiveC/main.m
+++ b/src/ExecutorObjectiveC/main.m
@@ -10,17 +10,18 @@ int main(int argc, const char * argv[]) {
 
 Slim * slim;
 
-void runSlimServer() {
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
-        const char * slimPort = slimPortArg();
-        exit(runSlimSocketServer(slimPort));
-    });
-}
-
 const char * slimPortArg() {
     NSArray *args = [[NSProcessInfo processInfo] arguments];
     const char * port = [ args[1] cStringUsingEncoding:NSASCIIStringEncoding] ;
     return port;
+}
+
+void runSlimServer() {
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+        const char * slimPort = slimPortArg();
+        int result = runSlimSocketServer(slimPort);
+        exit(result);
+    });
 }
 
 int connection_handler(int socket) {

--- a/src/ExecutorObjectiveC/main.m
+++ b/src/ExecutorObjectiveC/main.m
@@ -12,7 +12,7 @@ Slim * slim;
 
 void runSlimServer() {
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
-        const char * slimPort = slimPortArg()
+        const char * slimPort = slimPortArg();
         exit(runSlimSocketServer(slimPort));
     });
 }

--- a/src/ExecutorObjectiveC/main.m
+++ b/src/ExecutorObjectiveC/main.m
@@ -1,0 +1,62 @@
+#import <Cocoa/Cocoa.h>
+#include <cslim/Slim.h>
+#include <cslim/SocketServer.h>
+#include <cslim/SlimConnectionHandler.h>
+#include <cslim/TcpComLink.h>
+
+int main(int argc, const char * argv[]) {
+    return NSApplicationMain(argc, argv);
+}
+
+Slim * slim;
+
+void runSlimServer() {
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+        const char * slimPort = slimPortArg()
+        exit(runSlimSocketServer(slimPort));
+    });
+}
+
+const char * slimPortArg() {
+    NSArray *args = [[NSProcessInfo processInfo] arguments];
+    const char * port = [ args[1] cStringUsingEncoding:NSASCIIStringEncoding] ;
+    return port;
+}
+
+int connection_handler(int socket) {
+    int result = 0;
+    TcpComLink * comLink = TcpComLink_Create(socket);
+    
+    result = Slim_HandleConnection(slim, (void*)comLink, &TcpComLink_send, &TcpComLink_recv);
+    
+    TcpComLink_Destroy(comLink);
+    
+    return result;
+}
+
+int runSlimSocketServer(const char * arg) {
+    
+    slim = Slim_Create();
+    SocketServer* server = SocketServer_Create();
+    SocketServer_register_handler(server, &connection_handler);
+    
+    int result = SocketServer_Run(server, (char*)arg);
+    
+    SocketServer_Destroy(server);
+    Slim_Destroy(slim);
+    return result;
+}
+
+@interface OCSlimNSApplicationRunner : NSApplication
+@end
+
+@implementation OCSlimNSApplicationRunner
+
+-(id) init {
+    if (self = [super init]) {
+        runSlimServer();
+    }
+    return self;
+}
+
+@end

--- a/tests/ObjectiveC/OCSObjectiveCtoCBridgeSpec.m
+++ b/tests/ObjectiveC/OCSObjectiveCtoCBridgeSpec.m
@@ -143,14 +143,14 @@ OCDSpec2Context(OCSObjectiveCtoCBridgeSpec) {
                 list = NSArray_ToSlimList(@[ @{@"employee number":@(1429), @"first name":@"Bob"},
                                              @{@"employee number":@(8832), @"first name":@"James"}
                                              ]);
-                SlimList *dictionaryA = SlimList_GetListAt(SlimList_GetListAt(list, 0), 0);
-                SlimList *dictionaryB = SlimList_GetListAt(SlimList_GetListAt(list, 0), 1);
+                SlimList *dictionaryA = SlimList_GetListAt(SlimList_GetListAt(list, 0), 1);
+                SlimList *dictionaryB = SlimList_GetListAt(SlimList_GetListAt(list, 0), 0);
                 [ExpectObj(SlimList_GetNSStringAt(dictionaryA, 0)) toBeEqualTo:@"employee number"];
                 [ExpectObj(SlimList_GetNSStringAt(dictionaryA, 1)) toBeEqualTo:@"1429"];
                 [ExpectObj(SlimList_GetNSStringAt(dictionaryB, 0)) toBeEqualTo:@"first name"];
                 [ExpectObj(SlimList_GetNSStringAt(dictionaryB, 1)) toBeEqualTo:@"Bob"];
-                SlimList *dictionaryAA = SlimList_GetListAt(SlimList_GetListAt(list, 1), 0);
-                SlimList *dictionaryBB = SlimList_GetListAt(SlimList_GetListAt(list, 1), 1);
+                SlimList *dictionaryAA = SlimList_GetListAt(SlimList_GetListAt(list, 1), 1);
+                SlimList *dictionaryBB = SlimList_GetListAt(SlimList_GetListAt(list, 1), 0);
                 [ExpectObj(SlimList_GetNSStringAt(dictionaryAA, 0)) toBeEqualTo:@"employee number"];
                 [ExpectObj(SlimList_GetNSStringAt(dictionaryAA, 1)) toBeEqualTo:@"8832"];
                 [ExpectObj(SlimList_GetNSStringAt(dictionaryBB, 0)) toBeEqualTo:@"first name"];

--- a/tests/ObjectiveC/OCSReturnValueSpec.m
+++ b/tests/ObjectiveC/OCSReturnValueSpec.m
@@ -33,12 +33,17 @@ OCDSpec2Context(OCSReturnValueSpec) {
             [ExpectObj(classNameFor(@"methodReturningNSString")) toBeEqualTo: @"__NSCFConstantString"];
             [ExpectObj(result) toBeEqualTo: @"Hello World"];
         });
+  
+        It(@"returns the result for class NSTaggedPointerString", ^{
+            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturning__NSTaggedPointerString")];
+            [ExpectObj(classNameFor(@"methodReturning__NSTaggedPointerString")) toBeEqualTo: @"NSTaggedPointerString"];
+            [ExpectObj(result) toBeEqualTo: @"1234.5"];
+        });
         
         It(@"returns the result for class __NSCFString", ^{
             result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturning__NSCFString")];
-            
             [ExpectObj(classNameFor(@"methodReturning__NSCFString")) toBeEqualTo: @"__NSCFString"];
-            [ExpectObj(result) toBeEqualTo: @"1234.5"];
+            [ExpectObj(result) toBeEqualTo: @"Hello World"];
         });
         
         It(@"returns the result for class __NSCFConstantString", ^{
@@ -70,6 +75,18 @@ OCDSpec2Context(OCSReturnValueSpec) {
             result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningBOOLNO")];
             
             [ExpectObj(result) toBeEqualTo: @"false"];
+        });
+        
+        It(@"returns the value of false Bool", ^{
+            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningBoolFalse")];
+            
+            [ExpectObj(result) toBeEqualTo: @"false"];
+        });
+        
+        It(@"returns the value of true Bool", ^{
+            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningBoolTrue")];
+            
+            [ExpectObj(result) toBeEqualTo: @"true"];
         });
         
         It(@"returns OK for void", ^{

--- a/tests/ObjectiveC/ValidReturnTypes.m
+++ b/tests/ObjectiveC/ValidReturnTypes.m
@@ -11,8 +11,12 @@
     return @"Hello World";
 }
 
+-(NSString*) methodReturning__NSTaggedPointerString {
+    return [NSString stringWithFormat:@"%g",1234.5];
+}
+
 -(NSString*) methodReturning__NSCFString {
-    return [NSString stringWithFormat: @"%g", 1234.5];
+    return [[NSMutableString alloc] initWithString:@"Hello World"];
 }
 
 -(NSString*) methodReturning__NSCFConstantString {
@@ -36,6 +40,14 @@
 
 -(BOOL) methodReturningBOOLNO {
     return NO;
+}
+
+-(_Bool)methodReturningBoolFalse {
+    return false;
+}
+
+-(_Bool)methodReturningBoolTrue {
+    return true;
 }
 
 - (NSArray *)methodReturningArray {


### PR DESCRIPTION
- Supports C99 Bool Type as returned now by methods() -> Bool  written with Swift
In addition adds support for recent SDK changes.
- Some NSStrings now use the NSTaggedPointerString class which were not supported. 
- Fixes Tests failing due to change in ordering of objects in lists generated from NSDictionaries