### PR TITLE
OCSlim Update to support CocoaPod Spec Lint

### DIFF
--- a/bin/Mac/RunSlimTestsTargetWithSlimPort
+++ b/bin/Mac/RunSlimTestsTargetWithSlimPort
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-SLIM_PORT=$1 xcodebuild -workspace "___PROJECTNAME___.xcodeproj/project.xcworkspace/" -scheme "___TARGETNAME___" -sdk macosx10.8 -configuration Debug clean build
+SLIM_PORT=$1 xcodebuild -workspace "___PROJECTNAME___.xcodeproj/project.xcworkspace/" -scheme "___TARGETNAME___" -sdk macosx-configuration Debug clean build

--- a/bin/Mac/RunSlimTestsTargetWithSlimPort
+++ b/bin/Mac/RunSlimTestsTargetWithSlimPort
@@ -1,3 +1,3 @@
 #! /bin/sh
 
-SLIM_PORT=$1 xcodebuild -workspace "___PROJECTNAME___.xcodeproj/project.xcworkspace/" -scheme "___TARGETNAME___" -sdk macosx-configuration Debug clean build
+SLIM_PORT=$1 xcodebuild -workspace "___PROJECTNAME___.xcodeproj/project.xcworkspace/" -scheme "___TARGETNAME___" -sdk macosx -configuration Debug clean build

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'EPL', :file => 'LICENSE' }
   s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
   s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "v#{s.version}" }
-  s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*', 'src/fixtures/Main.c'
+  s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*', 'fixtures/Main.c'
   s.ios.exclude_files= 'src/ExecutorObjectiveC/main.m'
-  s.osx.exclude_files = 'src/fixtures/Main.c'
+  s.osx.exclude_files = 'fixtures/Main.c'
   s.private_header_files = "**/*.h"
 end

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -8,8 +8,7 @@ Pod::Spec.new do |s|
   s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
   s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "v#{s.version}" }
   s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*'
-  s.exclude_files = 'src/ExecutorObjectiveC/main.*'
   s.ios.source_files = 'src/ExecutorObjectiveC/main.c'
-  s.ios.source_files = 'src/ExecutorObjectiveC/main.m'
+  s.osx.source_files = 'src/ExecutorObjectiveC/main.m'
   s.private_header_files = "**/*.h"
 end

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
   s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "v#{s.version}" }
   s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*'
-  s.ios.source_files = 'src/ExecutorObjectiveC/main.c'
+  s.ios.source_files = 'src/fixtures/Main.c'
   s.osx.source_files = 'src/ExecutorObjectiveC/main.m'
   s.private_header_files = "**/*.h"
 end

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "cslim"
-  s.version      = "1.1.0"
+  s.version      = "1.1.1"
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "cslim"
-  s.version      = "1.1.2"
+  s.version      = "1.1.3"
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -8,5 +8,6 @@ Pod::Spec.new do |s|
   s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
   s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "v#{s.version}" }
   s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*'
+  s.ios.exclude_files = 'src/ExecutorObjectiveC/main.m'
   s.private_header_files = "**/*.h"
 end

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "cslim"
-  s.version      = "1.0.2"
+  s.version      = "1.1"
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "cslim"
-  s.version      = "1.1.1"
+  s.version      = "1.1.2"
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -1,14 +1,22 @@
 Pod::Spec.new do |s|
 
   s.name         = "cslim"
-  s.version      = "1.1"
+  s.version      = "1.1.0"
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }
   s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
   s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "v#{s.version}" }
   s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*', 'fixtures/Main.c'
-  s.ios.exclude_files= 'src/ExecutorObjectiveC/main.m'
-  s.osx.exclude_files = 'fixtures/Main.c'
   s.private_header_files = "**/*.h"
+  
+  main_file_osx = 'src/ExecutorObjectiveC/main.m'
+  main_file_ios = 'fixtures/Main.c'
+  s.ios.exclude_files= main_file_osx
+  s.osx.exclude_files = main_file_ios
+
+  main_files_all = main_file_osx, main_file_ios
+  s.tvos.exclude_files = main_files_all
+  s.watchos.exclude_files = main_files_all
+
 end

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -8,6 +8,8 @@ Pod::Spec.new do |s|
   s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
   s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "v#{s.version}" }
   s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*'
-  s.ios.exclude_files = 'src/ExecutorObjectiveC/main.m'
+  s.exclude_files = 'src/ExecutorObjectiveC/main.*'
+  s.ios.source_files = 'src/ExecutorObjectiveC/main.c'
+  s.ios.source_files = 'src/ExecutorObjectiveC/main.m'
   s.private_header_files = "**/*.h"
 end

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -7,8 +7,8 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'EPL', :file => 'LICENSE' }
   s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
   s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "v#{s.version}" }
-  s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*'
+  s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*', 'src/fixtures/Main.c'
   s.ios.exclude_files= 'src/ExecutorObjectiveC/main.m'
-  s.osx.source_files = 'src/fixtures/Main.c'
+  s.osx.exclude_files = 'src/fixtures/Main.c'
   s.private_header_files = "**/*.h"
 end

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
   s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "v#{s.version}" }
   s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*'
-  s.ios.source_files = 'src/fixtures/Main.c'
-  s.osx.source_files = 'src/ExecutorObjectiveC/main.m'
+  s.ios.exclude_files= 'src/ExecutorObjectiveC/main.m'
+  s.osx.source_files = 'src/fixtures/Main.c'
   s.private_header_files = "**/*.h"
 end

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }
   s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
-  s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "v#{s.version}" }
+  s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "#{s.version}" }
   s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*', 'fixtures/Main.c'
   s.private_header_files = "**/*.h"
   

--- a/src/ExecutorObjectiveC/OCSReturnValue.m
+++ b/src/ExecutorObjectiveC/OCSReturnValue.m
@@ -33,6 +33,8 @@
         return object;
     } else if ([NSStringFromClass([object class]) isEqualToString:@"NSTaggedPointerString"]) {
         return object;
+    } else if ([NSStringFromClass([object class]) isEqualToString:@"Swift._NSContiguousString"]) {
+        return object;
     } else if ([NSStringFromClass([object class]) isEqualToString:@"__NSArrayI"]) {
         return [self forNSArray:object];
     } else if ([NSStringFromClass([object class]) isEqualToString:@"__NSCFBoolean"]) {

--- a/src/ExecutorObjectiveC/OCSReturnValue.m
+++ b/src/ExecutorObjectiveC/OCSReturnValue.m
@@ -33,7 +33,7 @@
         return object;
     } else if ([NSStringFromClass([object class]) isEqualToString:@"NSTaggedPointerString"]) {
         return object;
-    } else if ([NSStringFromClass([object class]) isEqualToString:@"Swift._NSContiguousString"]) {
+    } else if ([NSStringFromClass([object class]) containsString:@"_NSContiguousString"]) {
         return object;
     } else if ([NSStringFromClass([object class]) isEqualToString:@"__NSArrayI"]) {
         return [self forNSArray:object];

--- a/src/ExecutorObjectiveC/main.m
+++ b/src/ExecutorObjectiveC/main.m
@@ -10,20 +10,6 @@ int main(int argc, const char * argv[]) {
 
 Slim * slim;
 
-const char * slimPortArg() {
-    NSArray *args = [[NSProcessInfo processInfo] arguments];
-    const char * port = [ args[1] cStringUsingEncoding:NSASCIIStringEncoding] ;
-    return port;
-}
-
-void runSlimServer() {
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
-        const char * slimPort = slimPortArg();
-        int result = runSlimSocketServer(slimPort);
-        exit(result);
-    });
-}
-
 int connection_handler(int socket) {
     int result = 0;
     TcpComLink * comLink = TcpComLink_Create(socket);
@@ -35,8 +21,13 @@ int connection_handler(int socket) {
     return result;
 }
 
+const char * slimPortArg() {
+    NSArray *args = [[NSProcessInfo processInfo] arguments];
+    const char * port = [ args[1] cStringUsingEncoding:NSASCIIStringEncoding] ;
+    return port;
+}
+
 int runSlimSocketServer(const char * arg) {
-    
     slim = Slim_Create();
     SocketServer* server = SocketServer_Create();
     SocketServer_register_handler(server, &connection_handler);
@@ -47,6 +38,16 @@ int runSlimSocketServer(const char * arg) {
     Slim_Destroy(slim);
     return result;
 }
+
+void runSlimServer() {
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^{
+        const char * slimPort = slimPortArg();
+        int result = runSlimSocketServer(slimPort);
+        exit(result);
+    });
+}
+
+
 
 @interface OCSlimNSApplicationRunner : NSApplication
 @end

--- a/tests/ObjectiveC/OCSReturnValueSpec.m
+++ b/tests/ObjectiveC/OCSReturnValueSpec.m
@@ -54,9 +54,9 @@ OCDSpec2Context(OCSReturnValueSpec) {
         });
         
         It(@"returns the result for a native Swift string class (_NSContigousString)", ^{
-            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturning__SwiftString")];
+            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningSwiftString")];
             
-            [ExpectObj(classNameFor(@"methodReturning__SwiftString")) toBeEqualTo: @"Swift._NSContiguousString"];
+            [ExpectObj(classNameFor(@"methodReturningSwiftString")) toBeEqualTo: @"Swift._NSContiguousString"];
             [ExpectObj(result) toBeEqualTo: @"Hello Swift"];
         });
         

--- a/tests/ObjectiveC/OCSReturnValueSpec.m
+++ b/tests/ObjectiveC/OCSReturnValueSpec.m
@@ -3,6 +3,7 @@
 #import "ValidReturnTypes.h"
 #import "SlimList.h"
 #import "SlimListSerializer.h"
+//#import "MacSpecs-Swift.h"
 
 NSMethodSignature* forSelector(SEL selector) {
     return [[[ValidReturnTypes alloc] init] methodSignatureForSelector: selector];
@@ -56,7 +57,8 @@ OCDSpec2Context(OCSReturnValueSpec) {
         It(@"returns the result for a native Swift string class (_NSContigousString)", ^{
             result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningSwiftString")];
             
-            [ExpectObj(classNameFor(@"methodReturningSwiftString")) toBeEqualTo: @"Swift._NSContiguousString"];
+            
+            [ExpectStr(classNameFor(@"methodReturningSwiftString")) toContain:@"_NSContiguousString"];
             [ExpectObj(result) toBeEqualTo: @"Hello Swift"];
         });
         

--- a/tests/ObjectiveC/OCSReturnValueSpec.m
+++ b/tests/ObjectiveC/OCSReturnValueSpec.m
@@ -53,6 +53,14 @@ OCDSpec2Context(OCSReturnValueSpec) {
             [ExpectObj(result) toBeEqualTo: @"Foobar"];
         });
         
+        It(@"returns the result for a native Swift string class (_NSContigousString)", ^{
+            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturning__SwiftString")];
+            
+            [ExpectObj(classNameFor(@"methodReturning__SwiftString")) toBeEqualTo: @"Swift._NSContiguousString"];
+            [ExpectObj(result) toBeEqualTo: @"Hello Swift"];
+        });
+        
+        
         It(@"returns the value of an NSNumber", ^{
             result = [OCSReturnValue forInvocation: invocationForMethodNamed( @"methodReturningNSNumber")];
             

--- a/tests/ObjectiveC/ValidReturnTypes.swift
+++ b/tests/ObjectiveC/ValidReturnTypes.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension ValidReturnTypes {
+
+    func methodReturning__SwiftString() -> String {
+        return "Hello Swift"
+    }
+    
+}

--- a/tests/ObjectiveC/ValidReturnTypes.swift
+++ b/tests/ObjectiveC/ValidReturnTypes.swift
@@ -2,8 +2,16 @@ import Foundation
 
 extension ValidReturnTypes {
 
-    func methodReturning__SwiftString() -> String {
+    func methodReturningSwiftString() -> String {
         return "Hello Swift"
+    }
+    
+    func methodReturningSwiftC99BoolTrue() -> Bool {
+        return true
+    }
+    
+    func methodReturningSwiftC99BoolFalse() -> Bool {
+        return false
     }
     
 }


### PR DESCRIPTION
- Updates Podspec to fix compiler issue for unsupported platforms tvOS and watchOS during spec lint
- Fixes errors generated during pod lib lint due to out of order functions in main.m
- Adds support for Swift native string return types

These changes allowed the spec to satisfy the requirements of pod spec lint so it could be submitted to the CocoaPods repo. This version is already available via CocoaPods.