### PR TITLE
Adds support for NSSingleObjectArray on macOS Sierra. 

### DIFF
--- a/cslim.podspec
+++ b/cslim.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "cslim"
-  s.version      = "1.1.3"
+  s.version      = "1.1.4"
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "cslim"
-  s.version      = "1.1.4"
+  s.version      = "1.1.5"
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }

--- a/cslim.podspec
+++ b/cslim.podspec
@@ -5,11 +5,12 @@ Pod::Spec.new do |s|
   s.summary      = "An implementation of FitNesse SliM for C and Objective-C"
   s.homepage     = "https://github.com/dougbradbury/cslim"
   s.license      = { :type => 'EPL', :file => 'LICENSE' }
-  s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer" 
-  s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "#{s.version}" }
-  s.source_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h', 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*', 'fixtures/Main.c'
-  s.private_header_files = "**/*.h"
+  s.authors      = "Robert Martin", "James Grenning", "Doug Bradbury", "Eric Myer"
   
+  s.source       = { :git => "https://github.com/paulstringer/cslim.git", :tag  => "#{s.version}" }
+  s.source_files = 'src/Com/*', 'src/CSlim/*', 'src/ExecutorObjectiveC/*', 'fixtures/Main.c', 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h'
+  s.private_header_files = 'include/Com/*.h', 'include/CSlim/*.h', 'include/ExecutorObjectiveC/*.h'
+    
   main_file_osx = 'src/ExecutorObjectiveC/main.m'
   main_file_ios = 'fixtures/Main.c'
   s.ios.exclude_files= main_file_osx

--- a/src/ExecutorObjectiveC/OCSReturnValue.m
+++ b/src/ExecutorObjectiveC/OCSReturnValue.m
@@ -35,7 +35,7 @@
         return object;
     } else if ([NSStringFromClass([object class]) containsString:@"_NSContiguousString"]) {
         return object;
-    } else if ([NSStringFromClass([object class]) isEqualToString:@"__NSArrayI"]) {
+    } else if ([NSStringFromClass([object class]) containsString:@"Array"]) {
         return [self forNSArray:object];
     } else if ([NSStringFromClass([object class]) isEqualToString:@"__NSCFBoolean"]) {
         return ((NSNumber *)object).boolValue ? @"true" : @"false";

--- a/src/ExecutorObjectiveC/OCSReturnValue.m
+++ b/src/ExecutorObjectiveC/OCSReturnValue.m
@@ -5,24 +5,16 @@
 @implementation OCSReturnValue
 
 +(NSString*) forInvocation:(NSInvocation*) invocation {
-    if ([self signatureHasReturnTypeVoid: invocation.methodSignature]) {
+    if ([self invocationHasReturnTypeVoid: invocation]) {
         return @"OK";
-    } else if ([self signatureHasReturnTypeObject:invocation.methodSignature]){
-        id result;
-        [invocation getReturnValue: &result];
-        return [OCSReturnValue forObject:result];
+    } else if ([self invocationHasReturnTypeObject:invocation]){
+        return [OCSReturnValue forReturnTypeObjectInvocation:invocation];
     } else {
-        return [OCSReturnValue forPrimitiveReturnTypeInvocation:invocation];
+        return [OCSReturnValue forReturnTypePrimitiveInvocation:invocation];
     }
 }
 
-+(BOOL) signatureHasReturnTypeObject:(NSMethodSignature *)signature {
-    NSString* returnType = [NSString stringWithUTF8String: [signature methodReturnType]];
-    return [returnType isEqualToString:@"@"];
-}
-
-+ (NSString *) forObjectReturnTypeInvocation:(NSInvocation *) invocation {
-    
++ (NSString *) forReturnTypeObjectInvocation:(NSInvocation *) invocation {
     id object;
     [invocation getReturnValue: &object];
     return [OCSReturnValue forObject:object];
@@ -48,8 +40,9 @@
     }
 }
 
-+ (NSString *) forPrimitiveReturnTypeInvocation:(NSInvocation *)invocation {
-    NSString* returnType = [NSString stringWithUTF8String: [invocation.methodSignature methodReturnType]];
++ (NSString *) forReturnTypePrimitiveInvocation:(NSInvocation *)invocation {
+    
+    NSString* returnType = [self returnTypeStringForInvocation:invocation];
     
     if ([returnType isEqualToString: @"i"] || [returnType isEqualToString:@"q"]) {
         int result;
@@ -73,15 +66,22 @@
     
 }
 
-
-+(BOOL) signatureHasReturnTypeVoid:(NSMethodSignature*) methodSignature {
-    return [[NSString stringWithUTF8String: [methodSignature methodReturnType]] isEqualToString: @"v"];
-}
-
 + (NSString *) forNSArray:(NSArray *)array {
     SlimList *slimlist = NSArray_ToSlimList(array);
     NSString *result = CStringToNSString(SlimList_Serialize(slimlist));
     return result;
+}
+
++(BOOL) invocationHasReturnTypeObject:(NSInvocation *)invocation {
+    return [[self returnTypeStringForInvocation:invocation] isEqualToString:@"@"];
+}
+
++ (BOOL) invocationHasReturnTypeVoid:(NSInvocation *) invocation {
+    return [[self returnTypeStringForInvocation: invocation] isEqualToString: @"v"];
+}
+
++ (NSString *) returnTypeStringForInvocation:(NSInvocation *)invocation {
+    return [NSString stringWithUTF8String: [invocation.methodSignature methodReturnType]];
 }
 
 @end

--- a/src/ExecutorObjectiveC/main.m
+++ b/src/ExecutorObjectiveC/main.m
@@ -1,8 +1,8 @@
 #import <Cocoa/Cocoa.h>
-#include <cslim/Slim.h>
-#include <cslim/SocketServer.h>
-#include <cslim/SlimConnectionHandler.h>
-#include <cslim/TcpComLink.h>
+#include <CSlim/Slim.h>
+#include <CSlim/SocketServer.h>
+#include <CSlim/SlimConnectionHandler.h>
+#include <CSlim/TcpComLink.h>
 
 int main(int argc, const char * argv[]) {
     return NSApplicationMain(argc, argv);

--- a/tests/ObjectiveC/OCSReturnValueSpec.m
+++ b/tests/ObjectiveC/OCSReturnValueSpec.m
@@ -75,6 +75,36 @@ OCDSpec2Context(OCSReturnValueSpec) {
             [ExpectObj(result) toBeEqualTo: @"456"];
         });
         
+        It(@"returns the value of a float", ^{
+            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningFloat")];
+            
+            [ExpectObj(result) toBeEqualTo: @"3.14159"];
+        });
+        
+        It(@"returns the value of a double", ^{
+            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningDouble")];
+            
+            [ExpectObj(result) toBeEqualTo: @"123.45"];
+        });
+        
+        It(@"returns the value of a Swift Double", ^{
+            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningSwiftDouble")];
+            
+            [ExpectObj(result) toBeEqualTo: @"123.45"];
+        });
+        
+        It(@"returns the value of a Swift Float", ^{
+            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningSwiftFloat")];
+            
+            [ExpectObj(result) toBeEqualTo: @"3.14159"];
+        });
+
+        It(@"returns the value of a Swift Int", ^{
+            result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningSwiftInt")];
+            
+            [ExpectObj(result) toBeEqualTo: @"789"];
+        });
+        
         It(@"returns the value of YES BOOL", ^{
             result = [OCSReturnValue forInvocation: invocationForMethodNamed(@"methodReturningBOOLYES")];
             

--- a/tests/ObjectiveC/ValidReturnTypes.m
+++ b/tests/ObjectiveC/ValidReturnTypes.m
@@ -30,6 +30,14 @@
     return 456;
 }
 
+- (double) methodReturningDouble {
+    return 123.45;
+}
+
+- (float) methodReturningFloat {
+    return  3.14159;
+}
+
 -(RespondsToStringValue*) methodReturningObjectThatRespondsToStringValue {
     return [[RespondsToStringValue alloc] init];
 }

--- a/tests/ObjectiveC/ValidReturnTypes.swift
+++ b/tests/ObjectiveC/ValidReturnTypes.swift
@@ -14,4 +14,15 @@ extension ValidReturnTypes {
         return false
     }
     
+    func methodReturningSwiftInt() -> Int {
+        return 789
+    }
+    
+    func methodReturningSwiftDouble() -> Double {
+        return 123.45
+    }
+    
+    func methodReturningSwiftFloat() -> Float {
+        return  3.14159
+    }
 }


### PR DESCRIPTION
- Matches for more types of Array with a more promiscous matching of "Array" class names.
- Adds support for Objc and Swift primitive types Int, Double and Float