### PR TITLE
Add support for Slim protocol V0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ CslimExample.  Add this to your CslimExample page:
         !define TEST_SYSTEM {slim}
         !define TEST_RUNNER {<path>/cslim/Cslim_cslim}
         !define COMMAND_PATTERN {%m}
-        !define SLIM_VERSION {0.1}
+        !define SLIM_VERSION {0.2}
 
 If you are using a unix based system, make a symbolic link in
 fitnesse/FitNesseRoot/CslimExample pointing to cslim/fixtures/pages, with a

--- a/fixtures/pages/FixtureChainTest/content.txt
+++ b/fixtures/pages/FixtureChainTest/content.txt
@@ -1,0 +1,26 @@
+|script  |Echo         |
+|$ECHO=  |echo|Echo    |
+|$LOUDLY=|echo|Loudly  |
+|$DIV=   |echo|Division|
+|$ROW=   |echo|Row     |
+
+|script|$ECHO       |
+|check |echo|123|123|
+
+|script|$ECHO_Loudly|
+|check |echo|abc|ABC|
+
+|script|Echo_$LOUDLY|
+|check |echo|def|DEF|
+
+|script|$ECHO_$LOUDLY|
+|check |echo |ghi|GHI|
+
+
+|$DIV                           |
+|numerator|denominator|Quotient?|
+|10       |5          |2        |
+
+!|Query: EmployeePayRecords$ROW|
+|id            |pay            |
+|1             |1000           |

--- a/fixtures/pages/FixtureChainTest/properties.xml
+++ b/fixtures/pages/FixtureChainTest/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/src/CSlim/SlimConnectionHandler.c
+++ b/src/CSlim/SlimConnectionHandler.c
@@ -60,7 +60,7 @@ int read_size(SlimConnectionHandler* self)
 int SlimConnectionHandler_Run(SlimConnectionHandler* self)
 {
 
-	if (self->sendFunc(self->comLink, "Slim -- V0.1\n", 13) == -1)
+	if (self->sendFunc(self->comLink, "Slim -- V0.2\n", 13) == -1)
 	{
 		return -1;
 	}

--- a/src/ExecutorC/StatementExecutor.c
+++ b/src/ExecutorC/StatementExecutor.c
@@ -54,13 +54,14 @@ struct StatementExecutor
 static void destroyInstances(InstanceNode*);
 static void destroyFixtures(FixtureNode*);
 static void destroyMethods(MethodNode*);
+static FixtureNode* replaceSymbolsAndFindFixture(StatementExecutor* executor, const char* className);
 static int isLibraryInstanceName(const char* instanceName);
 static void pushInstance(InstanceNode** stack, InstanceNode* instanceNode);
 static MethodNode* findMethodNode(MethodNode* methodNodes, const char* methodName);
 static char* invokeMethodOnInstanceWithArguments(StatementExecutor* executor, MethodNode* methodNode, InstanceNode* instanceNode, SlimList* args);
 void replaceSymbols(SymbolTable*, SlimList*);
-static char* replaceString(SymbolTable*, char*);
-static char* replaceStringFrom(SymbolTable*, char*, char*);
+static char* replaceString(SymbolTable*, const char*);
+static char* replaceStringFrom(SymbolTable*, const char*, const char*);
 static int lengthOfSymbol(char *);
 static FixtureNode * findFixture(StatementExecutor* executor, char const * className);
 static void Null_Destroy(void* self);
@@ -140,7 +141,7 @@ static void destroyMethods(MethodNode* head) {
 }
 
 char* StatementExecutor_Make(StatementExecutor* executor, char const* instanceName, char const* className, SlimList* args){
-	FixtureNode* fixtureNode = findFixture(executor, className);
+	FixtureNode* fixtureNode = replaceSymbolsAndFindFixture(executor, className);
 	if (fixtureNode) {
 		InstanceNode* instanceNode = (InstanceNode* )malloc(sizeof(InstanceNode));
 		if (isLibraryInstanceName(instanceName)) {
@@ -191,6 +192,14 @@ char* StatementExecutor_Call(StatementExecutor* executor, char const* instanceNa
 	return executor->message;
 }
 
+static FixtureNode* replaceSymbolsAndFindFixture(StatementExecutor* executor, const char* className)
+{
+	char* replacedClassName = replaceString(executor->symbolTable, className);
+	FixtureNode* fixtureNode = findFixture(executor, replacedClassName);
+	free(replacedClassName);
+	return fixtureNode;
+}
+
 static int isLibraryInstanceName(const char* instanceName)
 {
 	return CSlim_StringStartsWith(instanceName, "library");
@@ -239,11 +248,11 @@ void replaceSymbols(SymbolTable* symbolTable, SlimList* list) {
 	}
 }
 
-static char* replaceString(SymbolTable* symbolTable, char* string) {
+static char* replaceString(SymbolTable* symbolTable, const char* string) {
 	return replaceStringFrom(symbolTable, string, string);
 }
 
-static char* replaceStringFrom(SymbolTable* symbolTable, char* string, char* from) {
+static char* replaceStringFrom(SymbolTable* symbolTable, const char* string, const char* from) {
 	char * dollarSign = strpbrk(from, "$");
 	if (dollarSign)
 	{

--- a/tests/CSlim/SlimConnectionHandlerTest.cpp
+++ b/tests/CSlim/SlimConnectionHandlerTest.cpp
@@ -101,7 +101,7 @@ TEST(SlimConnectionHandler, ShouldSendVersion)
 
   SlimConnectionHandler_Run(slimConnectionHandler);
   
-  STRCMP_EQUAL("Slim -- V0.1\n", comLink.lastSendMsg);
+  STRCMP_EQUAL("Slim -- V0.2\n", comLink.lastSendMsg);
 }
 
 TEST(SlimConnectionHandler, ShouldReadMessageAndCallSlimHandler)
@@ -114,7 +114,7 @@ TEST(SlimConnectionHandler, ShouldReadMessageAndCallSlimHandler)
   
   SlimConnectionHandler_Run(slimConnectionHandler);
   
-  STRCMP_EQUAL("Slim -- V0.1\n000007:ghijklm", comLink.lastSendMsg);
+  STRCMP_EQUAL("Slim -- V0.2\n000007:ghijklm", comLink.lastSendMsg);
   STRCMP_EQUAL("abcdef", sentSlimMessage);
   CHECK_EQUAL(mockMessageHandler, sentMsgHandler);
 }

--- a/tests/CSlim/StatementExecutorTest.cpp
+++ b/tests/CSlim/StatementExecutorTest.cpp
@@ -217,6 +217,35 @@ TEST(StatementExecutor, canReplaceSymbolsInSubSubLists)
 	SlimList_Destroy(returnedSubList);
 }
 
+TEST(StatementExecutor, canCreateFixtureWithSymbolAsClassName)
+{
+	StatementExecutor_SetSymbol(statementExecutor, "fixtureName", "Test_Slim");
+	char* makeResponse = StatementExecutor_Make(statementExecutor, "instanceName", "$fixtureName", empty);
+	STRCMP_EQUAL("OK", makeResponse);
+}
+
+TEST(StatementExecutor, shouldNotAllowAMakeOnANonexistentClassReferencedBySymbol)
+{
+	StatementExecutor_SetSymbol(statementExecutor, "fixtureName", "NoSuchClass");
+	char* makeResponse = StatementExecutor_Make(statementExecutor, "instanceName", "$fixtureName", empty);
+	STRCMP_EQUAL("__EXCEPTION__:message:<<NO_CLASS $fixtureName.>>", makeResponse);
+}
+
+TEST(StatementExecutor, canCreateFixtureWithSymbolInClassName)
+{
+	StatementExecutor_SetSymbol(statementExecutor, "test", "Test");
+	char* makeResponse = StatementExecutor_Make(statementExecutor, "instanceName", "$test_Slim", empty);
+	STRCMP_EQUAL("OK", makeResponse);
+}
+
+TEST(StatementExecutor, canCreateFixtureWithMultipleSymbolsInClassName)
+{
+	StatementExecutor_SetSymbol(statementExecutor, "test", "Test");
+	StatementExecutor_SetSymbol(statementExecutor, "slim", "Slim");
+	char* makeResponse = StatementExecutor_Make(statementExecutor, "instanceName", "$test_$slim", empty);
+	STRCMP_EQUAL("OK", makeResponse);
+}
+
 TEST(StatementExecutor, canCreateFixtureWithArguments) 
 {
 	SlimList* constructionArgs = SlimList_Create();
@@ -264,6 +293,15 @@ TEST(StatementExecutor, fixtureConstructionFailsWithUserErrorMessage)
 	STRCMP_EQUAL("__EXCEPTION__:message:<<COULD_NOT_INVOKE_CONSTRUCTOR TestSlim xxx.>>", result);
 	
 	SlimList_Destroy(constructionArgs);
+}
+
+TEST(StatementExecutor, fixtureReferencedBySymbolConstructionFailsWithUserErrorMessage)
+{
+	StatementExecutor_SetSymbol(statementExecutor, "fixtureName", "Test_Slim");
+	SlimList_AddString(args, "arg0");
+	SlimList_AddString(args, "arg1");
+	char* makeResponse = StatementExecutor_Make(statementExecutor, "instanceName", "$fixtureName", args);
+	STRCMP_EQUAL("__EXCEPTION__:message:<<COULD_NOT_INVOKE_CONSTRUCTOR $fixtureName xxx.>>", makeResponse);
 }
 
 TEST(StatementExecutor, fixtureCanReturnError) 


### PR DESCRIPTION
Allow symbols in the class name passed to a make command. This brings the protocol to version 0.2 as described on fitnesse.org.

Please review at your convenience. Thank you!