### PR TITLE
Fix build for Visual Studio 2017

### DIFF
--- a/fixtures/DecisionTableExample.c
+++ b/fixtures/DecisionTableExample.c
@@ -4,10 +4,14 @@
 #include "SlimList.h"
 #include "Fixtures.h"
 
+#if defined(_MSC_VER) && (_MSC_VER <= 1800) // Visual Studio 2013
+#define snprintf _snprintf
+#endif
+
 typedef struct Division
 {
-	float numerator;
-	float denominator;
+	double numerator;
+	double denominator;
 	char result[32];
 } Division;
 
@@ -39,7 +43,7 @@ static char* setDenominator(void* void_self, SlimList* args) {
 
 static char* Quotient(void* void_self, SlimList* args) {
 	Division* self = (Division*)void_self;
-	float quotient = self->numerator / self->denominator;
+	double quotient = self->numerator / self->denominator;
 	snprintf(self->result, 32, "%g", quotient);
 	return self->result;
 }

--- a/fixtures/ExceptionsExample.c
+++ b/fixtures/ExceptionsExample.c
@@ -4,9 +4,7 @@
 #include "SlimList.h"
 #include "Fixtures.h"
 
-typedef struct ExceptionsExample
-{
-} ExceptionsExample;
+typedef void ExceptionsExample;
 
 void* ExceptionsExample_Create(StatementExecutor* errorHandler, SlimList* args)
 {
@@ -15,8 +13,8 @@ void* ExceptionsExample_Create(StatementExecutor* errorHandler, SlimList* args)
 		return NULL;
 	}
 
-	ExceptionsExample* self = (ExceptionsExample*)malloc(sizeof(ExceptionsExample));
-	memset(self, 0, sizeof(ExceptionsExample));
+	ExceptionsExample* self = (ExceptionsExample*)malloc(1);
+	memset(self, 0, 1);
 	return self;
 }
 

--- a/fixtures/FixtureInCpp.cpp
+++ b/fixtures/FixtureInCpp.cpp
@@ -4,17 +4,21 @@
 #include "SlimList.h"
 #include "Fixtures.h"
 
+#if defined(_MSC_VER) && (_MSC_VER <= 1800) // Visual Studio 2013
+#define snprintf _snprintf
+#endif
+
 class cMultiplication 
 {
 public:
 	cMultiplication(){};
 	~cMultiplication(){};
-	float product()
+	double product()
 	{
 		return m1*m2;
 	}
-	float m1;
-	float m2;
+	double m1;
+	double m2;
 	char result[32];	
 };
 
@@ -56,7 +60,7 @@ static char* setMultiplicand2(void* void_self, SlimList* args) {
 
 static char* Product(void* void_self, SlimList* args) {
 	Multiplication* self = (Multiplication*)void_self;
-	float product = self->multiplication.product();
+	double product = self->multiplication.product();
 	snprintf(self->result, 32, "%g", product);
 	return self->result;
 }

--- a/fixtures/ScriptTableExample.c
+++ b/fixtures/ScriptTableExample.c
@@ -5,6 +5,10 @@
 #include "Fixtures.h"
 #include "SlimList.h"
 
+#if defined(_MSC_VER) && (_MSC_VER <= 1800) // Visual Studio 2013
+#define snprintf _snprintf
+#endif
+
 typedef struct Count
 {
 	int count;

--- a/src/CSlim/ListExecutor.c
+++ b/src/CSlim/ListExecutor.c
@@ -5,6 +5,9 @@
 #include <stdio.h>
 #include <string.h>
 
+#if defined(_MSC_VER) && (_MSC_VER <= 1800) // Visual Studio 2013
+#define snprintf _snprintf
+#endif
 
 struct ListExecutor
 {

--- a/src/ExecutorC/StatementExecutor.c
+++ b/src/ExecutorC/StatementExecutor.c
@@ -11,6 +11,9 @@
 #include "assert.h"
 #include <ctype.h>
 
+#if defined(_MSC_VER) && (_MSC_VER <= 1800) // Visual Studio 2013
+#define snprintf _snprintf
+#endif
 
 typedef struct methodNode {
 	struct methodNode* next;

--- a/tests/CSlim/SlimConnectionHandlerTest.cpp
+++ b/tests/CSlim/SlimConnectionHandlerTest.cpp
@@ -5,6 +5,10 @@
 #include <stdio.h>
 #include <assert.h>
 
+#if defined(_MSC_VER) && (_MSC_VER <= 1800) // Visual Studio 2013
+#define snprintf _snprintf
+#endif
+
 extern "C"
 {
   #include "SlimConnectionHandler.h"

--- a/tests/CSlim/TestSlim.c
+++ b/tests/CSlim/TestSlim.c
@@ -3,6 +3,10 @@
 #include <string.h>
 #include <stdio.h>
 
+#if defined(_MSC_VER) && (_MSC_VER <= 1800) // Visual Studio 2013
+#define snprintf _snprintf
+#endif
+
 //static local variables
 struct TestSlim
 {


### PR DESCRIPTION
* warning C4244: '=' : conversion from 'double' to 'float', possible loss of data
* snprintf() is only available since Visual Studio 2015: `error C3861: snprintf identifier not found`
* fix error C2016: C requires that a struct or union has at least one member
* sizeof(void) is not supported by Visual Studio
```
c:\users\mlongo\documents\cslim\fixtures\exceptionsexample.c(17): error C2070: 'ExceptionsExample': illegal sizeof operand [C:\Users\mlongo\Documents\cslim\build-dir\fixtures\examples.vcxproj]
c:\users\mlongo\documents\cslim\fixtures\exceptionsexample.c(18): error C2070: 'ExceptionsExample': illegal sizeof operand [C:\Users\mlongo\Documents\cslim\build-dir\fixtures\examples.vcxproj]
```
[\[Visual Studio 2017\] sizeof Operator](https://docs.microsoft.com/en-us/cpp/cpp/sizeof-operator):
>  The sizeof operator cannot be used with the following operands:
> - ...
> - The type void.

and GCC has an extension to support it but triggers a warning
```
/home/mlongo/Documents/cslim/fixtures/ExceptionsExample.c: In function ‘void* ExceptionsExample_Create(StatementExecutor*, SlimList*)’:
/home/mlongo/Documents/cslim/fixtures/ExceptionsExample.c:17:80: warning: invalid application of ‘sizeof’ to a void type [-Wpointer-arith]
   ExceptionsExample* self = (ExceptionsExample*)malloc(sizeof(ExceptionsExample));
                                                                                ^
/home/mlongo/Documents/cslim/fixtures/ExceptionsExample.c:18:43: warning: invalid application of ‘sizeof’ to a void type [-Wpointer-arith]
   memset(self, 0, sizeof(ExceptionsExample));
                                           ^
```
[\[GCC 8.1\] Arithmetic on void- and Function-Pointers](https://gcc.gnu.org/onlinedocs/gcc-8.1.0/gcc/Pointer-Arith.html#Pointer-Arith):
> In GNU C, addition and subtraction operations are supported on pointers to void and on pointers to functions. This is done by treating the size of a void or of a function as 1.
A consequence of this is that sizeof is also allowed on void and on function types, and returns 1. 