### PR TITLE
fix double free

### DIFF
--- a/tests/CSlim/SlimConnectionHandlerTest.cpp
+++ b/tests/CSlim/SlimConnectionHandlerTest.cpp
@@ -53,13 +53,16 @@ extern "C"
     return result;
   }
 
-  char * slimResponse;
   char sentSlimMessage[32];
   void * sentMsgHandler;
   char * mock_handle_slim_message(void* self, char * message)
   {
     strcpy(sentSlimMessage, message);
     sentMsgHandler = self;
+
+    static char * slimResponse = NULL;
+    slimResponse = (char*)malloc(8 * sizeof(char));
+    strcpy(slimResponse, "ghijklm");
     return slimResponse;
   }
   
@@ -108,9 +111,6 @@ TEST(SlimConnectionHandler, ShouldReadMessageAndCallSlimHandler)
 {
   comLink.recvStream = "000006:abcdef000003:bye";
   comLink.recvPtr = comLink.recvStream;
-  
-  slimResponse = (char*)cpputest_malloc(8);
-  strcpy(slimResponse, "ghijklm");
   
   SlimConnectionHandler_Run(slimConnectionHandler);
   


### PR DESCRIPTION
```
./bin/CSlim-tests -v
TEST(SlimUtil, StringStartsWith) - 0 ms
TEST(SlimUtil, CanConcatenateToANonEmptyString) - 0 ms
TEST(SlimUtil, CanConcatenateToAnEmptyString) - 0 ms
TEST(SlimUtil, CanCreateEmptyString) - 0 ms
TEST(StatementExecutorWithLibraryInstances, callMethodThatDoesNotExistOnGivenInstanceOrLibraryInstancesReturnsException) - 1 ms
TEST(StatementExecutorWithLibraryInstances, callsMethodOnBottomOfLibraryInstanceStackWhenNotFoundOnGivenInstance) - 0 ms
TEST(StatementExecutorWithLibraryInstances, callsMethodOnTopOfLibraryInstanceStackWhenNotFoundOnGivenInstance) - 1 ms
TEST(StatementExecutorWithLibraryInstances, callsMethodOnLibraryInstanceWhenNotFoundOnGivenInstance) - 0 ms
TEST(StatementExecutorWithLibraryInstances, callsMethodOnInstanceFirst) - 0 ms
TEST(StatementExecutor, canHaveNullResult) - 1 ms
TEST(StatementExecutor, canCallFixtureNotDeclared) - 0 ms
TEST(StatementExecutor, canCallFixtureDeclaredBackwards) - 0 ms
TEST(StatementExecutor, fixtureCanReturnError) - 0 ms
TEST(StatementExecutor, fixtureReferencedBySymbolConstructionFailsWithUserErrorMessage) - 0 ms
TEST(StatementExecutor, fixtureConstructionFailsWithUserErrorMessage) - 0 ms
TEST(StatementExecutor, canCreateFixtureWithArgumentsThatHaveMultipleSymbols) - 1 ms
TEST(StatementExecutor, canCreateFixtureWithArgumentsThatHaveSymbols) - 0 ms
TEST(StatementExecutor, canCreateFixtureWithArguments) - 0 ms
TEST(StatementExecutor, canCreateFixtureWithMultipleSymbolsInClassName) - 0 ms
TEST(StatementExecutor, canCreateFixtureWithSymbolInClassName) - 0 ms
TEST(StatementExecutor, shouldNotAllowAMakeOnANonexistentClassReferencedBySymbol) - 0 ms
TEST(StatementExecutor, canCreateFixtureWithSymbolAsClassName) - 0 ms
TEST(StatementExecutor, canReplaceSymbolsInSubSubLists) - 1 ms
TEST(StatementExecutor, canReplaceSymbolsInSubLists) - 0 ms
TEST(StatementExecutor, canHandleDollarSignAtTheEndOfTheString) - 0 ms
TEST(StatementExecutor, canHandlestringWithJustADollarSign) - 0 ms
TEST(StatementExecutor, canReplaceMultipleSymbolsWithTheirValue) - 0 ms
TEST(StatementExecutor, canReplaceSymbolsWithOtherNonAlphaNumeric) - 0 ms
TEST(StatementExecutor, canReplaceSymbolsInTheMiddle) - 0 ms
TEST(StatementExecutor, canReplaceSymbolsWithTheirValue) - 0 ms
TEST(StatementExecutor, canCreateTwoDifferentFixtures) - 0 ms
TEST(StatementExecutor, canCallTwoInstancesOfTheSameFixture) - 0 ms
TEST(StatementExecutor, WhereCalledFunctionHasUnderscoresSeparatingNameParts) - 0 ms
TEST(StatementExecutor, canCallaMethodThatTakesASlimList) - 0 ms
TEST(StatementExecutor, canCallaMethodThatReturnsAValue) - 0 ms
TEST(StatementExecutor, shouldNotAllowAMakeOnANonexistentClass) - 0 ms
TEST(StatementExecutor, shouldNotAllowACallToaNonexistentInstance) - 0 ms
TEST(StatementExecutor, shouldKnowNumberofArgumentsforNonExistantFunction) - 0 ms
TEST(StatementExecutor, shouldTruncateReallyLongNamedFunctionThatDoesNotExistTo32) - 0 ms
TEST(StatementExecutor, cantCallFunctionThatDoesNotExist) - 0 ms
TEST(StatementExecutor, canCallFunctionWithNoArguments) - 0 ms
TEST(SlimListSerializer, serializeMultibyteCharacters) - 0 ms
TEST(SlimListSerializer, serializeNull) - 0 ms
TEST(SlimListSerializer, serializedLength) - 0 ms
TEST(SlimListSerializer, SerializeNestedList) - 0 ms
TEST(SlimListSerializer, canCopyAList) - 1 ms
TEST(SlimListSerializer, ListCopysItsString) - 0 ms
TEST(SlimListSerializer, SerializeAListWithTwoElements) - 0 ms
TEST(SlimListSerializer, SerializeAListWithOneElements) - 0 ms
TEST(SlimListSerializer, SerializeAListWithNoElements) - 0 ms
TEST(SlimList, iteratorGetString) - 0 ms
TEST(SlimList, iteratorNext) - 0 ms
TEST(SlimList, iteratorHasItem) - 0 ms
TEST(SlimList, iteratorDoesNotHaveAnItemWhenEmpty) - 0 ms
TEST(SlimList, CanInsertAfterPoppingListWithEntries) - 0 ms
TEST(SlimList, CanPopHeadOnListWithOneEntry) - 0 ms
TEST(SlimList, toStringForLongList) - 2 ms
TEST(SlimList, recursiveToString) - 0 ms
TEST(SlimList, toStringDoesNotHaveASideEffectWhichChangesResultsFromPriorCalls) - 0 ms
TEST(SlimList, toStringForSimpleList) - 0 ms
TEST(SlimList, ToStringForEmptyList) - 0 ms
TEST(SlimList, getDouble) - 0 ms
TEST(SlimList, canGetTail) - 0 ms
TEST(SlimList, canReplaceString) - 0 ms
TEST(SlimList, cannotGetElementThatAreNotThere) - 0 ms
TEST(SlimList, canGetHashWithMultipleElements) - 0 ms
TEST(SlimList, canGetHashWithOneElement) - 0 ms
TEST(SlimList, canGetElements) - 0 ms
TEST(SlimList, twoNonIdenticalMultipleElementListsElmementsAreNotEqual) - 0 ms
TEST(SlimList, twoIdenticalMultipleElementListsElmementsAreEqual) - 0 ms
TEST(SlimList, twoSingleElementListsWithDifferentElmementsAreNotEqual) - 0 ms
TEST(SlimList, twoDifferentLenghtListsAreNotEqual) - 0 ms
TEST(SlimList, twoEmptyListsAreEqual) - 0 ms
TEST(SlimConnectionHandler, HandlesSendErrorWithoutMemoryLeak) - 0 ms
TEST(SlimConnectionHandler, CanMockSendResultsAsPartOfTest) - 1 ms
TEST(SlimConnectionHandler, ShouldReadMessageAndCallSlimHandler)=================================================================
==25079==ERROR: AddressSanitizer: attempting double-free on 0x60200000c150 in thread T0:
    #0 0x7fafd1ebc7b8 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7b8)
    #1 0x563bc511709c in TEST_GROUP_CppUTestGroupSlimConnectionHandler::teardown() /home/mlongo/Documents/cslim/tests/CSlim/SlimConnectionHandlerTest.cpp:106
    #2 0x563bc514b141 in PlatformSpecificSetJmpImplementation (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x69141)
    #3 0x563bc5146cbd in Utest::run() (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x64cbd)
    #4 0x563bc51474f2 in helperDoRunOneTestInCurrentProcess (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x654f2)
    #5 0x563bc514b141 in PlatformSpecificSetJmpImplementation (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x69141)
    #6 0x563bc5146dc7 in UtestShell::runOneTest(TestPlugin*, TestResult&) (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x64dc7)
    #7 0x563bc514de0c in TestRegistry::runAllTests(TestResult&) (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x6be0c)
    #8 0x563bc5134828 in CommandLineTestRunner::runAllTests() (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x52828)
    #9 0x563bc513502b in CommandLineTestRunner::RunAllTests(int, char const**) (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x5302b)
    #10 0x563bc510fbb9 in main /home/mlongo/Documents/cslim/tests/AllTests.cpp:6
    #11 0x7fafd10cab96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #12 0x563bc510fab9 in _start (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x2dab9)

0x60200000c150 is located 0 bytes inside of 8-byte region [0x60200000c150,0x60200000c158)
freed by thread T0 here:
    #0 0x7fafd1ebc7b8 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7b8)
    #1 0x563bc512bdc2 in SlimList_Release /home/mlongo/Documents/cslim/src/CSlim/SlimListSerializer.c:74
    #2 0x563bc5129cdd in SlimConnectionHandler_Run /home/mlongo/Documents/cslim/src/CSlim/SlimConnectionHandler.c:102
    #3 0x563bc5116872 in TEST_SlimConnectionHandler_ShouldReadMessageAndCallSlimHandler_Test::testBody() /home/mlongo/Documents/cslim/tests/CSlim/SlimConnectionHandlerTest.cpp:125
    #4 0x563bc514b141 in PlatformSpecificSetJmpImplementation (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x69141)
    #5 0x60800000001f  (<unknown module>)

previously allocated by thread T0 here:
    #0 0x7fafd1ebcb50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x563bc5117043 in TEST_GROUP_CppUTestGroupSlimConnectionHandler::setup() /home/mlongo/Documents/cslim/tests/CSlim/SlimConnectionHandlerTest.cpp:98
    #2 0x563bc514b141 in PlatformSpecificSetJmpImplementation (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x69141)
    #3 0x60800000001f  (<unknown module>)

SUMMARY: AddressSanitizer: double-free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7b8) in __interceptor_free
==25079==ABORTING
```