### PR TITLE
fix memory leak

### DIFF
--- a/tests/CSlim/SlimListSerializerTest.cpp
+++ b/tests/CSlim/SlimListSerializerTest.cpp
@@ -79,8 +79,8 @@ TEST(SlimListSerializer, canCopyAList)
 	STRCMP_EQUAL(serialCopy, serialSlimList);
 
 	SlimList_Destroy(copy);
-	cpputest_free(serialSlimList);
-	cpputest_free(serialCopy);
+	free(serialSlimList);
+	free(serialCopy);
 
 }
 


### PR DESCRIPTION
```
./bin/CSlim-tests -v
TEST(SlimUtil, StringStartsWith) - 0 ms
TEST(SlimUtil, CanConcatenateToANonEmptyString) - 0 ms
TEST(SlimUtil, CanConcatenateToAnEmptyString) - 0 ms
TEST(SlimUtil, CanCreateEmptyString) - 0 ms
TEST(StatementExecutorWithLibraryInstances, callMethodThatDoesNotExistOnGivenInstanceOrLibraryInstancesReturnsException) - 0 ms
TEST(StatementExecutorWithLibraryInstances, callsMethodOnBottomOfLibraryInstanceStackWhenNotFoundOnGivenInstance) - 1 ms
TEST(StatementExecutorWithLibraryInstances, callsMethodOnTopOfLibraryInstanceStackWhenNotFoundOnGivenInstance) - 0 ms
TEST(StatementExecutorWithLibraryInstances, callsMethodOnLibraryInstanceWhenNotFoundOnGivenInstance) - 0 ms
TEST(StatementExecutorWithLibraryInstances, callsMethodOnInstanceFirst) - 0 ms
TEST(StatementExecutor, canHaveNullResult) - 0 ms
TEST(StatementExecutor, canCallFixtureNotDeclared) - 0 ms
TEST(StatementExecutor, canCallFixtureDeclaredBackwards) - 0 ms
TEST(StatementExecutor, fixtureCanReturnError) - 0 ms
TEST(StatementExecutor, fixtureReferencedBySymbolConstructionFailsWithUserErrorMessage) - 0 ms
TEST(StatementExecutor, fixtureConstructionFailsWithUserErrorMessage) - 0 ms
TEST(StatementExecutor, canCreateFixtureWithArgumentsThatHaveMultipleSymbols) - 0 ms
TEST(StatementExecutor, canCreateFixtureWithArgumentsThatHaveSymbols) - 0 ms
TEST(StatementExecutor, canCreateFixtureWithArguments) - 0 ms
TEST(StatementExecutor, canCreateFixtureWithMultipleSymbolsInClassName) - 1 ms
TEST(StatementExecutor, canCreateFixtureWithSymbolInClassName) - 0 ms
TEST(StatementExecutor, shouldNotAllowAMakeOnANonexistentClassReferencedBySymbol) - 0 ms
TEST(StatementExecutor, canCreateFixtureWithSymbolAsClassName) - 0 ms
TEST(StatementExecutor, canReplaceSymbolsInSubSubLists) - 0 ms
TEST(StatementExecutor, canReplaceSymbolsInSubLists) - 1 ms
TEST(StatementExecutor, canHandleDollarSignAtTheEndOfTheString) - 0 ms
TEST(StatementExecutor, canHandlestringWithJustADollarSign) - 0 ms
TEST(StatementExecutor, canReplaceMultipleSymbolsWithTheirValue) - 0 ms
TEST(StatementExecutor, canReplaceSymbolsWithOtherNonAlphaNumeric) - 0 ms
TEST(StatementExecutor, canReplaceSymbolsInTheMiddle) - 0 ms
TEST(StatementExecutor, canReplaceSymbolsWithTheirValue) - 0 ms
TEST(StatementExecutor, canCreateTwoDifferentFixtures) - 1 ms
TEST(StatementExecutor, canCallTwoInstancesOfTheSameFixture) - 0 ms
TEST(StatementExecutor, WhereCalledFunctionHasUnderscoresSeparatingNameParts) - 0 ms
TEST(StatementExecutor, canCallaMethodThatTakesASlimList) - 0 ms
TEST(StatementExecutor, canCallaMethodThatReturnsAValue) - 0 ms
TEST(StatementExecutor, shouldNotAllowAMakeOnANonexistentClass) - 0 ms
TEST(StatementExecutor, shouldNotAllowACallToaNonexistentInstance) - 0 ms
TEST(StatementExecutor, shouldKnowNumberofArgumentsforNonExistantFunction) - 0 ms
TEST(StatementExecutor, shouldTruncateReallyLongNamedFunctionThatDoesNotExistTo32) - 0 ms
TEST(StatementExecutor, cantCallFunctionThatDoesNotExist) - 0 ms
TEST(StatementExecutor, canCallFunctionWithNoArguments) - 0 ms
TEST(SlimListSerializer, serializeMultibyteCharacters) - 0 ms
TEST(SlimListSerializer, serializeNull) - 0 ms
TEST(SlimListSerializer, serializedLength) - 0 ms
TEST(SlimListSerializer, SerializeNestedList) - 0 ms
TEST(SlimListSerializer, canCopyAList)
/home/mlongo/Documents/cslim/tests/CSlim/SlimListSerializerTest.cpp:62: error: Failure in TEST(SlimListSerializer, canCopyAList)
canCopyAList:62: error:
	Deallocating non-allocated memory
   allocated at file: <unknown> line: 0 size: 0 type: unknown
   deallocated at file: <unknown> line: 0 type: free


 - 0 ms
TEST(SlimListSerializer, ListCopysItsString) - 0 ms
TEST(SlimListSerializer, SerializeAListWithTwoElements) - 0 ms
TEST(SlimListSerializer, SerializeAListWithOneElements) - 0 ms
TEST(SlimListSerializer, SerializeAListWithNoElements) - 0 ms
TEST(SlimList, iteratorGetString) - 0 ms
TEST(SlimList, iteratorNext) - 0 ms
TEST(SlimList, iteratorHasItem) - 0 ms
TEST(SlimList, iteratorDoesNotHaveAnItemWhenEmpty) - 0 ms
TEST(SlimList, CanInsertAfterPoppingListWithEntries) - 0 ms
TEST(SlimList, CanPopHeadOnListWithOneEntry) - 0 ms
TEST(SlimList, toStringForLongList) - 2 ms
TEST(SlimList, recursiveToString) - 0 ms
TEST(SlimList, toStringDoesNotHaveASideEffectWhichChangesResultsFromPriorCalls) - 0 ms
TEST(SlimList, toStringForSimpleList) - 0 ms
TEST(SlimList, ToStringForEmptyList) - 0 ms
TEST(SlimList, getDouble) - 0 ms
TEST(SlimList, canGetTail) - 1 ms
TEST(SlimList, canReplaceString) - 0 ms
TEST(SlimList, cannotGetElementThatAreNotThere) - 0 ms
TEST(SlimList, canGetHashWithMultipleElements) - 0 ms
TEST(SlimList, canGetHashWithOneElement) - 0 ms
TEST(SlimList, canGetElements) - 0 ms
TEST(SlimList, twoNonIdenticalMultipleElementListsElmementsAreNotEqual) - 0 ms
TEST(SlimList, twoIdenticalMultipleElementListsElmementsAreEqual) - 0 ms
TEST(SlimList, twoSingleElementListsWithDifferentElmementsAreNotEqual) - 0 ms
TEST(SlimList, twoDifferentLenghtListsAreNotEqual) - 0 ms
TEST(SlimList, twoEmptyListsAreEqual) - 0 ms
TEST(SlimConnectionHandler, HandlesSendErrorWithoutMemoryLeak) - 1 ms
TEST(SlimConnectionHandler, CanMockSendResultsAsPartOfTest) - 0 ms
TEST(SlimConnectionHandler, ShouldReadMessageAndCallSlimHandler) - 0 ms
TEST(SlimConnectionHandler, ShouldSendVersion) - 0 ms
TEST(SymbolTable, CanGetLengthOfNonExistentSymbol) - 0 ms
TEST(SymbolTable, CanGetLengthOfSymbol) - 0 ms
TEST(SymbolTable, findSymbolShouldReturnSymbol) - 0 ms
TEST(SymbolTable, findNonExistentSymbolShouldReturnNull) - 0 ms
TEST(ListExecutor, CanPassASymbolInAList) - 1 ms
TEST(ListExecutor, CanReturnNull) - 0 ms
TEST(ListExecutor, CanPassAndReturnAList) - 1 ms
TEST(ListExecutor, CanReplateMultipleSymbolsInASingleArgument) - 0 ms
TEST(ListExecutor, CanAssignTheReturnValueToASymbol) - 1 ms
TEST(ListExecutor, CanCallAFunctionMoreThanOnce) - 0 ms
TEST(ListExecutor, CanPassArgumentsToConstructor) - 1 ms
TEST(ListExecutor, ShouldRespondToAnEmptySetOfInstructionsWithAnEmptySetOfResults) - 0 ms
TEST(ListExecutor, CantCallAmethodOnAnInstanceThatDoesntExist) - 0 ms
TEST(ListExecutor, CantExecuteMalformedInstruction) - 0 ms
TEST(ListExecutor, CanCallASimpleFunction) - 0 ms
TEST(ListExecutor, CannotExecuteAnInvalidOperation) - 0 ms
TEST(ListExecutor, ImportShouldReturnOk) - 0 ms
TEST(SlimListDeserializer, getStringWhereThereIsAList) - 0 ms
TEST(SlimListDeserializer, canAddSubList) - 1 ms
TEST(SlimListDeserializer, canDeSerializeListWithTwoElements) - 0 ms
TEST(SlimListDeserializer, canDeSerializeListWithOneElement) - 0 ms
TEST(SlimListDeserializer, canDeserializeWithMultibyteCharacters) - 0 ms
TEST(SlimListDeserializer, canDeserializeCanonicalListWithOneElement) - 0 ms
TEST(SlimListDeserializer, MissingClosingBracketReturnsNull) - 0 ms
TEST(SlimListDeserializer, MissingOpenBracketReturnsNull) - 0 ms
TEST(SlimListDeserializer, deserializeEmptyString) - 0 ms
TEST(SlimListDeserializer, deserializeNull) - 0 ms
TEST(SlimListDeserializer, deserializeEmptyList) - 0 ms

Errors (1 failures, 105 tests, 105 ran, 182 checks, 0 ignored, 0 filtered out, 19 ms)


=================================================================
==25662==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 446 byte(s) in 7 object(s) allocated from:
    #0 0x7fd7e8574b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x5595e0954e3e in TestMemoryAllocator::alloc_memory(unsigned long, char const*, int) (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x59e3e)

Direct leak of 38 byte(s) in 1 object(s) allocated from:
    #0 0x7fd7e8574b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x5595e0944bd4 in SlimList_Serialize /home/mlongo/Documents/cslim/src/CSlim/SlimListSerializer.c:48
    #2 0x5595e0935803 in TEST_SlimListSerializer_canCopyAList_Test::testBody() /home/mlongo/Documents/cslim/tests/CSlim/SlimListSerializerTest.cpp:74
    #3 0x5595e0964131 in PlatformSpecificSetJmpImplementation (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x69131)
    #4 0x60800000001f  (<unknown module>)

Direct leak of 38 byte(s) in 1 object(s) allocated from:
    #0 0x7fd7e8574b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x5595e0944bd4 in SlimList_Serialize /home/mlongo/Documents/cslim/src/CSlim/SlimListSerializer.c:48
    #2 0x5595e09357ef in TEST_SlimListSerializer_canCopyAList_Test::testBody() /home/mlongo/Documents/cslim/tests/CSlim/SlimListSerializerTest.cpp:73
    #3 0x5595e0964131 in PlatformSpecificSetJmpImplementation (/home/mlongo/Documents/cslim/build-dir/bin/CSlim-tests+0x69131)
    #4 0x60800000001f  (<unknown module>)

SUMMARY: AddressSanitizer: 522 byte(s) leaked in 9 allocation(s).
```