### PR TITLE
Revert "fix double free"

### DIFF
--- a/tests/CSlim/SlimConnectionHandlerTest.cpp
+++ b/tests/CSlim/SlimConnectionHandlerTest.cpp
@@ -55,16 +55,13 @@ extern "C"
     return result;
   }
 
+  char * slimResponse;
   char sentSlimMessage[32];
   void * sentMsgHandler;
   char * mock_handle_slim_message(void* self, char * message)
   {
     strcpy(sentSlimMessage, message);
     sentMsgHandler = self;
-
-    static char * slimResponse = NULL;
-    slimResponse = (char*)malloc(8 * sizeof(char));
-    strcpy(slimResponse, "ghijklm");
     return slimResponse;
   }
   
@@ -113,6 +110,9 @@ TEST(SlimConnectionHandler, ShouldReadMessageAndCallSlimHandler)
 {
   comLink.recvStream = "000006:abcdef000003:bye";
   comLink.recvPtr = comLink.recvStream;
+  
+  slimResponse = (char*)cpputest_malloc(8);
+  strcpy(slimResponse, "ghijklm");
   
   SlimConnectionHandler_Run(slimConnectionHandler);
   


### PR DESCRIPTION
This is causing an error on my mac build.  We need to figure out what the platform differences are here.
```tests/CSlim/SlimConnectionHandlerTest.cpp:112: error: Failure in TEST(SlimConnectionHandler, ShouldReadMessageAndCallSlimHandler)
ShouldReadMessageAndCallSlimHandler:112: error:
	Deallocating non-allocated memory
   allocated at file: <unknown> line: 0 size: 0 type: unknown
   deallocated at file: <unknown> line: 0 type: free```